### PR TITLE
(mod) prevent node-red from crashing in case of unknown devices

### DIFF
--- a/fhem-input.js
+++ b/fhem-input.js
@@ -81,7 +81,7 @@ module.exports = function (RED) {
                         send = false;
                     }
                     if (send) {
-                        msg.attributes = fhem.devicelist[msg.device].Attributes;
+                        msg.attributes = fhem.devicelist[msg.device]?.Attributes;
                         send_count++;
                         this.send(msg);
                     }


### PR DESCRIPTION
In case fhem-input receives a message from an unknown device, it crashes with:
```
[error] TypeError: Cannot read properties of undefined (reading 'Attributes')
    at EventEmitter.<anonymous> (/data/node_modules/node-red-contrib-fhem/fhem-input.js:84:70)
    at EventEmitter.emit (node:events:527:28)
```
Of course, unknown devices should not exist, but actually the device listing is requested with `jsonlist2 .* alias room` which can end in a complete empty list.

As I assume, there is always a scenario possible where fhem sends events for yet unknown devices, catching this case is a good practise, instead of letting node-red crashing.